### PR TITLE
Allow enabling error message display per edittext

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".PerFieldValidationActivity"
+            android:exported="true"
+            >
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/tmxlr/driodvalidatorlight/PerFieldValidationActivity.java
+++ b/app/src/main/java/com/tmxlr/driodvalidatorlight/PerFieldValidationActivity.java
@@ -1,0 +1,86 @@
+package com.tmxlr.driodvalidatorlight;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import com.tmxlr.lib.driodvalidatorlight.Form;
+import com.tmxlr.lib.driodvalidatorlight.helper.Range;
+import com.tmxlr.lib.driodvalidatorlight.helper.RegexTemplate;
+
+public class PerFieldValidationActivity extends AppCompatActivity implements TextWatcher, View.OnFocusChangeListener {
+
+    EditText editText;
+    EditText editText2;
+    Button btnNext;
+    Form form;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        editText = (EditText) findViewById(R.id.edit_text);
+        editText2 = (EditText) findViewById(R.id.edit_text2);
+        btnNext = (Button) findViewById(R.id.btn_validate);
+        btnNext.setText(R.string.button_next);
+        btnNext.setEnabled(false);
+        btnNext.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Toast.makeText(PerFieldValidationActivity.this, "Success", Toast.LENGTH_LONG).show();
+            }
+        });
+
+        form = new Form(this);
+        form.enablePerFieldErrorMessageDisplay();
+        form.check(editText, RegexTemplate.NOT_EMPTY_PATTERN, "Must not be empty");
+        form.check(editText, RegexTemplate.EMAIL_PATTERN, "Must be an Email");
+        form.checkLength(editText, Range.equalOrLess(12), "Text length must be less or equal to 12");
+
+        //form.checkValue(editText2, Range.equalOrMore(23), "Entered value must be greater equal than 23");
+        form.checkValue(editText2, Range.equalsOrMoreAndEqualsOrLess(-12, 12), "Entered value must between -12 and 12");
+
+        editText.addTextChangedListener(this);
+        editText2.addTextChangedListener(this);
+        editText.setOnFocusChangeListener(this);
+        editText2.setOnFocusChangeListener(this);
+
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+        //na
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        //na
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+        validate();
+    }
+
+    private void validate() {
+        if(form.validate()) {
+            btnNext.setEnabled(true);
+        } else {
+            btnNext.setEnabled(false);
+        }
+    }
+
+    @Override
+    public void onFocusChange(View v, boolean hasFocus) {
+        if (hasFocus) {
+            form.setShowError((EditText) v);
+            validate();
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="app_name">DriodValidatorLight</string>
+    <string name="app_name">DroidValidatorLight</string>
+    <string name="button_next">Next</string>
 </resources>

--- a/driodvalidatorlightlib/src/main/java/com/tmxlr/lib/driodvalidatorlight/Form.java
+++ b/driodvalidatorlightlib/src/main/java/com/tmxlr/lib/driodvalidatorlight/Form.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
 public class Form {
 
     public static final String TAG = Form.class.getSimpleName();
-    private static final int SHOW_ERRORS_TAG = Form.class.hashCode();
 
     final Context context;
     final Map<EditText, List<Validator>> fieldValidators;
@@ -67,7 +66,7 @@ public class Form {
     }
 
     public void setShowError(EditText editText) {
-        editText.setTag(SHOW_ERRORS_TAG, new Object());
+        editText.setTag(R.id.SHOW_ERRORS_TAG, new Object());
     }
 
     public boolean validate() {
@@ -97,7 +96,7 @@ public class Form {
             try {
                 if (!validator.isValid(editText.getText().toString())) {
                     if (!perFieldErrorMessageDisplay ||
-                            ((perFieldErrorMessageDisplay && editText.getTag(SHOW_ERRORS_TAG) != null))) {
+                            ((perFieldErrorMessageDisplay && editText.getTag(R.id.SHOW_ERRORS_TAG) != null))) {
                         editText.setError(validator.getMessage());
                     }
                     return false;

--- a/driodvalidatorlightlib/src/main/java/com/tmxlr/lib/driodvalidatorlight/Form.java
+++ b/driodvalidatorlightlib/src/main/java/com/tmxlr/lib/driodvalidatorlight/Form.java
@@ -22,15 +22,16 @@ import java.util.regex.Pattern;
 public class Form {
 
     public static final String TAG = Form.class.getSimpleName();
+    private static final int SHOW_ERRORS_TAG = Form.class.hashCode();
 
     final Context context;
     final Map<EditText, List<Validator>> fieldValidators;
+    private boolean perFieldErrorMessageDisplay = false;
 
     public Form(Context context) {
         this.context = context;
         this.fieldValidators = new HashMap<>();
     }
-
 
     public void check(EditText editText, String regex, String errMsg) {
         RegExpValidator validator = new RegExpValidator(Pattern.compile(regex), errMsg);
@@ -61,6 +62,14 @@ public class Form {
         addValidator(editText, validator);
     }
 
+    public void enablePerFieldErrorMessageDisplay() {
+        perFieldErrorMessageDisplay = true;
+    }
+
+    public void setShowError(EditText editText) {
+        editText.setTag(SHOW_ERRORS_TAG, new Object());
+    }
+
     public boolean validate() {
         boolean formValid = true;
         for (Map.Entry<EditText, List<Validator>> entry : fieldValidators.entrySet()) {
@@ -87,7 +96,10 @@ public class Form {
         for (Validator validator : validators) {
             try {
                 if (!validator.isValid(editText.getText().toString())) {
-                    editText.setError(validator.getMessage());
+                    if (!perFieldErrorMessageDisplay ||
+                            ((perFieldErrorMessageDisplay && editText.getTag(SHOW_ERRORS_TAG) != null))) {
+                        editText.setError(validator.getMessage());
+                    }
                     return false;
                 }
             } catch (ValidatorException e) {

--- a/driodvalidatorlightlib/src/main/java/com/tmxlr/lib/driodvalidatorlight/base/Validator.java
+++ b/driodvalidatorlightlib/src/main/java/com/tmxlr/lib/driodvalidatorlight/base/Validator.java
@@ -13,4 +13,5 @@ public abstract class Validator {
 	public String getMessage() {
 		return errorMessage;
 	}
+
 }

--- a/driodvalidatorlightlib/src/main/res/values/tags.xml
+++ b/driodvalidatorlightlib/src/main/res/values/tags.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="SHOW_ERRORS_TAG" type="id"/>
+</resources>


### PR DESCRIPTION
If using the validation "on the fly" while user enters data in each
field instead of in a final step for all fields, adding this feature
allows showing error messages on-demand, eg. only after user has given
focus to a field instead of displaying errors for every field being
validated.
Also includes a new example app activity to demo the new behaviour.